### PR TITLE
(archlinux/hypr) set correct monitors for desktop computer

### DIFF
--- a/archlinux/.config/hypr/hyprland.conf
+++ b/archlinux/.config/hypr/hyprland.conf
@@ -22,21 +22,21 @@
 ################
 
 # See https://wiki.hyprland.org/Configuring/Monitors/
-monitor=,preferred,auto,1                   # fallback for any unspecified monitor
-monitor=DP-2,2560x1440@144,0x0,1         # external monitor (primary)
-monitor=eDP-1,preferred,2560x0,1           # laptop screen (to the right)
+monitor=,preferred,auto,1                         # fallback for any unspecified monitor
+monitor=DP-1,2560x1440@144,0x0,1                 # main monitor (ASUS VG27AQ1A, horizontal)
+monitor=HDMI-A-2,1920x1080@180,2560x0,1,transform,1  # second monitor (LG ULTRAGEAR, vertical/portrait)
 
-# Workspaces 1-5 on external monitor, 6-10 on laptop
-workspace = 1, monitor:DP-2, default:true
-workspace = 2, monitor:DP-2
-workspace = 3, monitor:DP-2
-workspace = 4, monitor:DP-2
-workspace = 5, monitor:DP-2
-workspace = 6, monitor:eDP-1, default:true
-workspace = 7, monitor:eDP-1
-workspace = 8, monitor:eDP-1
-workspace = 9, monitor:eDP-1
-workspace = 10, monitor:eDP-1
+# Workspaces 1-5 on main monitor, 6-10 on second monitor
+workspace = 1, monitor:DP-1, default:true
+workspace = 2, monitor:DP-1
+workspace = 3, monitor:DP-1
+workspace = 4, monitor:DP-1
+workspace = 5, monitor:DP-1
+workspace = 6, monitor:HDMI-A-2, default:true
+workspace = 7, monitor:HDMI-A-2
+workspace = 8, monitor:HDMI-A-2
+workspace = 9, monitor:HDMI-A-2
+workspace = 10, monitor:HDMI-A-2
 
 ###################
 ### MY PROGRAMS ###


### PR DESCRIPTION
Update monitor config to use actual connector names (DP-1, HDMI-A-2) with correct resolutions/refresh rates and portrait rotation for the secondary 1080p monitor.